### PR TITLE
chore: add assets with different decimals to the Fairground network

### DIFF
--- a/fairground/templates/genesis-template.json
+++ b/fairground/templates/genesis-template.json
@@ -25,6 +25,62 @@
     ],
     "app_state": {
         "assets": {
+            "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4": {
+                "decimals": 5,
+                "name": "tEURO Fairground",
+                "quantum": "1",
+                "source": {
+                    "erc20": {
+                        "contract_address": "0x7119500C6327928ae4E64531feBB258f0a33A617",
+                        "lifetime_limit": "",
+                        "withdraw_threshold": ""
+                    }
+                },
+                "symbol": "tEURO",
+                "total_supply": "64999723000000000000000000"
+            },
+            "6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61": {
+                "decimals": 18,
+                "name": "tDAI Fairground",
+                "quantum": "1",
+                "source": {
+                    "erc20": {
+                        "contract_address": "0x973cB2a51F83a707509fe7cBafB9206982E1c3ad",
+                        "lifetime_limit": "",
+                        "withdraw_threshold": ""
+                    }
+                },
+                "symbol": "tDAI",
+                "total_supply": "64999723000000000000000000"
+            },
+            "993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede": {
+                "decimals": 6,
+                "name": "tUSDC Fairground",
+                "quantum": "1",
+                "source": {
+                    "erc20": {
+                        "contract_address": "0x40ff2D218740EF033b43B8Ce0342aEBC81934554",
+                        "lifetime_limit": "",
+                        "withdraw_threshold": ""
+                    }
+                },
+                "symbol": "tUSDC",
+                "total_supply": "64999723000000000000000000"
+            },
+            "5250f006831ceb27b83ac7068a049d6b4f60cf0f1254ccc3c4c11d8952e8cc1e": {
+                "decimals": 8,
+                "name": "tBTC Fairground",
+                "quantum": "1",
+                "source": {
+                    "erc20": {
+                        "contract_address": "0x123cB4a2AB190F88a50646D5436aB3F5859107Ed",
+                        "lifetime_limit": "",
+                        "withdraw_threshold": ""
+                    }
+                },
+                "symbol": "tBTC",
+                "total_supply": "64999723000000000000000000"
+            },
             "177e8f6c25a955bd18475084b99b2b1d37f28f3dec393fab7755a7e69c3d8c3b": {
                 "decimals": 5,
                 "name": "tEURO TEST",


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1274
closes vegaprotocol/ansible#276