### PR TITLE
chore: add explorer url for fairground config

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -2,6 +2,7 @@
   {
     "name": "fairground",
     "configFileUrl": "https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/fairground/vegawallet-fairground.toml",
+    "explorer": "https://explorer.fairground.wtf",
     "sha": "5b05d0ca9d1155b43ca5e9199e2414dec3dda102"
   }
 ]


### PR DESCRIPTION
Add explorer url to fairground config, same way as in https://github.com/vegaprotocol/networks/pull/117