### PR TITLE
feat: devnet genesis

### DIFF
--- a/devnet1/templates/genesis-template.json
+++ b/devnet1/templates/genesis-template.json
@@ -264,6 +264,7 @@
             "market.value.windowLength": "168h",
             "network.checkpoint.timeElapsedBetweenCheckpoints": "1m",
             "network.validators.minimumEthereumEventsForNewValidator": "0",
+            "network.validators.multisig.numberOfSigners": "5",
             "network.validators.tendermint.number": "5",
             "reward.asset": "fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55",
             "reward.staking.delegation.competitionLevel": "3.1",


### PR DESCRIPTION
"Jan 16 11:42:49 n01.devnet1.vega.xyz visor[2586585]: 2023-01-16T11:42:49.550Z        FATAL        processor        processor/abci.go:692        couldnt initialise vega with the genesis block        {"error": "network.validators.multisig.numberOfSigners: unable to validate network.validators.multisig.numberOfSigners: expect <= 5 (network.validators.tendermint.number * 1) got 13"}