### PR TITLE
fix: app urls

### DIFF
--- a/fairground/vegawallet-fairground.toml
+++ b/fairground/vegawallet-fairground.toml
@@ -19,6 +19,6 @@ name = "fairground"
     Hosts = ["https://api.n06.testnet.vega.xyz", "https://api.n07.testnet.vega.xyz"]
 
 [Apps]
-  Console = "console.fairground.wtf"
-  TokenDApp = "token.fairground.wtf"
-  Explorer = "explorer.fairground.wtf"
+  Console = "https://console.fairground.wtf"
+  TokenDApp = "https://token.fairground.wtf"
+  Explorer = "https://explorer.fairground.wtf"

--- a/stagnet1/vegawallet-stagnet1.toml
+++ b/stagnet1/vegawallet-stagnet1.toml
@@ -19,6 +19,6 @@ name = "stagnet1"
     Hosts = ["https://api.stagnet1.vega.xyz", "https://api.n05.stagnet1.vega.xyz", "https://api.n06.stagnet1.vega.xyz"]
 
 [Apps]
-  Console = "stagnet1.console.vega.xyz"
-  TokenDApp = "stagnet1.governance.vega.xyz"
-  Explorer = "stagnet1.explorer.vega.xyz"
+  Console = "https://stagnet1.console.vega.xyz"
+  TokenDApp = "https://stagnet1.governance.vega.xyz"
+  Explorer = "https://stagnet1.explorer.vega.xyz"

--- a/stagnet3/vegawallet-stagnet3.toml
+++ b/stagnet3/vegawallet-stagnet3.toml
@@ -19,6 +19,6 @@ name = "stagnet3"
     Hosts = ["https://api.stagnet3.vega.xyz", "https://api.n05.stagnet3.vega.xyz", "https://api.n06.stagnet3.vega.xyz", "https://api.n07.stagnet3.vega.xyz"]
 
 [Apps]
-  Console = "stagnet3.console.vega.xyz"
-  TokenDApp = "stagnet3.governance.vega.xyz"
-  Explorer = "stagnet3.explorer.vega.xyz"
+  Console = "https://stagnet3.console.vega.xyz"
+  TokenDApp = "https://stagnet3.governance.vega.xyz"
+  Explorer = "https://stagnet3.explorer.vega.xyz"


### PR DESCRIPTION
Related to https://github.com/vegaprotocol/vegawallet-desktop/issues/679

Without the protocol prefix, the desktop wallet fails to open the correct links for the dApps.