### PR TITLE
feat: update deployment_block for the devnet1 smart contracts

### DIFF
--- a/devnet1/genesis.json
+++ b/devnet1/genesis.json
@@ -189,7 +189,7 @@
       "propose_market_enabled": true
     },
     "network_parameters": {
-      "blockchains.ethereumConfig": "{ \"network_id\": \"11155111\", \"chain_id\": \"11155111\", \"confirmations\": 3, \"collateral_bridge_contract\": { \"address\": \"0xeb43b95378cE195B03e760749B4e416f4ff1e187\" }, \"staking_bridge_contract\": { \"address\": \"0x45F37Ebbe79F0629E6FCed2a2a75cad9567dFd3d\", \"deployment_block_height\": 3737999 }, \"token_vesting_contract\": { \"address\": \"0x29574E929eFEdd83cC5637313a44378648044cC4\", \"deployment_block_height\": 3738002 }, \"multisig_control_contract\": { \"address\": \"0x79aC716EBfF5a64dAE5E4993eeB3fA048f46E3cB\", \"deployment_block_height\": 3737993 } }",
+      "blockchains.ethereumConfig": "{ \"network_id\": \"11155111\", \"chain_id\": \"11155111\", \"confirmations\": 3, \"collateral_bridge_contract\": { \"address\": \"0xeb43b95378cE195B03e760749B4e416f4ff1e187\" }, \"staking_bridge_contract\": { \"address\": \"0x45F37Ebbe79F0629E6FCed2a2a75cad9567dFd3d\", \"deployment_block_height\": 3973200 }, \"token_vesting_contract\": { \"address\": \"0x29574E929eFEdd83cC5637313a44378648044cC4\", \"deployment_block_height\": 3973200 }, \"multisig_control_contract\": { \"address\": \"0x79aC716EBfF5a64dAE5E4993eeB3fA048f46E3cB\", \"deployment_block_height\": 3973200 } }",
       "governance.proposal.asset.maxClose": "8760h0m0s",
       "governance.proposal.asset.maxEnact": "8760h0m0s",
       "governance.proposal.asset.minClose": "5s",

--- a/devnet1/templates/genesis-template.json
+++ b/devnet1/templates/genesis-template.json
@@ -212,7 +212,7 @@
             "propose_market_enabled": true
         },
         "network_parameters": {
-            "blockchains.ethereumConfig": "{ \"network_id\": \"11155111\", \"chain_id\": \"11155111\", \"confirmations\": 3, \"collateral_bridge_contract\": { \"address\": \"0xeb43b95378cE195B03e760749B4e416f4ff1e187\" }, \"staking_bridge_contract\": { \"address\": \"0x45F37Ebbe79F0629E6FCed2a2a75cad9567dFd3d\", \"deployment_block_height\": 3737999 }, \"token_vesting_contract\": { \"address\": \"0x29574E929eFEdd83cC5637313a44378648044cC4\", \"deployment_block_height\": 3738002 }, \"multisig_control_contract\": { \"address\": \"0x79aC716EBfF5a64dAE5E4993eeB3fA048f46E3cB\", \"deployment_block_height\": 3737993 } }",
+            "blockchains.ethereumConfig": "{ \"network_id\": \"11155111\", \"chain_id\": \"11155111\", \"confirmations\": 3, \"collateral_bridge_contract\": { \"address\": \"0xeb43b95378cE195B03e760749B4e416f4ff1e187\" }, \"staking_bridge_contract\": { \"address\": \"0x45F37Ebbe79F0629E6FCed2a2a75cad9567dFd3d\", \"deployment_block_height\": 3973200 }, \"token_vesting_contract\": { \"address\": \"0x29574E929eFEdd83cC5637313a44378648044cC4\", \"deployment_block_height\": 3973200 }, \"multisig_control_contract\": { \"address\": \"0x79aC716EBfF5a64dAE5E4993eeB3fA048f46E3cB\", \"deployment_block_height\": 3973200 } }",
             "governance.proposal.asset.maxClose": "8760h0m0s",
             "governance.proposal.asset.maxEnact": "8760h0m0s",
             "governance.proposal.asset.minClose": "5s",


### PR DESCRIPTION
We need to do it to avoid spamming Sepolia during the restart from block 0