### PR TITLE
feat: tune btc incentive market

### DIFF
--- a/fairground/research-bots-config.toml
+++ b/fairground/research-bots-config.toml
@@ -33,8 +33,8 @@ passphrase_file = "./assets/passphrase.txt"
         mdp = 4
         pdp = 0
     [scenario.btcusd_perpetual_incentive.market_maker_args]
-        market_kappa = 0.15
-        market_order_arrival_rate = 100
+        market_kappa = 0.3
+        market_order_arrival_rate = 150
         order_kappa = 0.15
         order_size = 1
         order_levels = 25
@@ -44,7 +44,7 @@ passphrase_file = "./assets/passphrase.txt"
         inventory_upper_boundary = 3
         fee_amount = 0.0001
         commitment_amount = 800000
-        initial_mint = 200000
+        initial_mint = 2000000
     [scenario.btcusd_perpetual_incentive.auction_trader_args]
         traders = 2
         initial_volume = 0.001
@@ -52,14 +52,14 @@ passphrase_file = "./assets/passphrase.txt"
     [scenario.btcusd_perpetual_incentive.random_trader_args]
         traders = 10
         order_intensity = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        order_volume = [0.001, 0.005, 0.01, 0.02, 0.6, 0.07, 0.09, 0.1, 0.4, 0.6, 0.8]
+        order_volume = [0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.12, 0.14, 0.16, 0.18]
         step_bias = [0.333, 0.222, 0.175, 0.130, 0.08, 0.06, 0.05, 0.03, 0.012, 0.008, 0.006]
         initial_mint = 1000000
     [scenario.btcusd_perpetual_incentive.sensitive_trader_args]
         traders = 10
         scale = [2, 4, 6, 8, 10, 12, 14, 16, 17, 20]
-        max_order_size = [0.001, 0.005, 0.01, 0.02, 0.05, 0.08, 0.1, 0.2, 0.3, 0.4]
-        initial_mint = 10000
+        max_order_size = [0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14]
+        initial_mint = 1000000
     [scenario.btcusd_perpetual_incentive.simulation_args]
         n_steps = 99999999
         granularity = "MINUTE"


### PR DESCRIPTION
PR makes following changes to config:

- tightens market maker spread to approx 6 USD
- corrects initial mint to be approx 2x commitment amount
- slightly reduces the order size of the large volume random traders (size of the orders driven more by intensity)
- slightly reduces the order size of the sensitive traders